### PR TITLE
Expose bits of GarbledInt type

### DIFF
--- a/compute/src/int.rs
+++ b/compute/src/int.rs
@@ -19,7 +19,7 @@ pub type GarbledInt1024 = GarbledInt<1024>;
 // Define a new type GarbledInt<N>
 #[derive(Debug, Clone)]
 pub struct GarbledInt<const N: usize> {
-    pub(crate) bits: Vec<bool>, // Store the bits of the signed integer (in two's complement form)
+    pub bits: Vec<bool>, // Store the bits of the signed integer (in two's complement form)
     _phantom: PhantomData<[bool; N]>, // PhantomData to ensure the N bit size
 }
 


### PR DESCRIPTION
Change the visibility of the bits field in the GarbledInt struct to public, allowing access to the underlying bit representation.