### PR TITLE
Fixed Division

### DIFF
--- a/compute/src/operations/circuits/types.rs
+++ b/compute/src/operations/circuits/types.rs
@@ -45,6 +45,10 @@ impl GateIndexVec {
     pub fn truncate(&mut self, len: usize) {
         self.0.truncate(len);
     }
+
+    pub fn set(&mut self, index: usize, value: GateIndex) {
+        self.0[index] = value;
+    }
 }
 
 // Implement indexing for GateVector


### PR DESCRIPTION
## **The Problem:**  
The original implementation mistakenly used plain Rust `if` statements to test circuit gate indices (e.g. `if ge_bit != GateIndex::default()`), which incorrectly assumes that a gate index can be interpreted as a Boolean value. In a garbled circuit, gate indices are simply labels; they don’t represent the logical 0/1 value directly. This led to unpredictable behavior: often causing overflows or incorrect results—and even index out-of-bound errors (e.g. accessing index 8 in an 8–bit vector).

Furthermore, the bit-shifting logic (using `insert(0, ...)`) was not consistently handling the ordering of bits (LSB-first vs MSB-first), potentially causing misaligned results.

## **The Fix:**  
1. **Remove Implicit Branching on Gate Indices:**  
   All decision-making is now performed with circuit-level multiplexer (MUX) gates rather than normal Rust `if` statements. Instead of testing `if ge_bit != GateIndex::default()`, we now compute:
   - A `ge_bit` using our `ge` function (which produces a circuit output representing 1 if the remainder is greater than or equal to the divisor, and 0 otherwise).  
   - Use `self.mux(&ge_bit, ...)` to conditionally select between `remainder - b` and `remainder`, and similarly for setting the quotient bit.

2. **Ensure Consistent Bit Ordering:**  
   We introduced helper functions `shift_left` and `set_lsb` so that our circuit consistently operates on numbers stored in LSB-first order.  
   - **`shift_left`** shifts an n-bit number left by one (inserting a 0 at the least significant position and dropping the most-significant bit).  
   - **`set_lsb`** replaces the least-significant bit with the specified bit from the dividend.  
   
   This approach ensures that during each iteration the remainder is updated correctly without out-of-bound access.

## **Outcome:**  
With these changes, the division circuit now uses MUX gates for conditional logic and maintains a consistent bit ordering. This fixes the index out-of-bound error and ensures that both the quotient and remainder are computed correctly for various test cases.