### PR TITLE
Encrypted Shift Right and Shift Left Circuits

### DIFF
--- a/compute/src/operations/circuits/traits.rs
+++ b/compute/src/operations/circuits/traits.rs
@@ -286,4 +286,28 @@ pub trait CircuitExecutor {
     ///
     /// A single element of type `Type` representing the logical OR result across the input vectors.
     fn lor(&mut self, a: &Self::TypeVec, b: &Self::TypeVec) -> Self::Type;
+
+    /// Shifts a vector to the left by a specified number of positions.
+    ///
+    /// # Parameters
+    ///
+    /// - `a`: A reference to the vector to be shifted.
+    /// - `shift`: A reference to the vector containing the number of positions to shift.
+    ///
+    /// # Returns
+    ///
+    /// A vector of elements resulting from the left shift operation.
+    fn shl(&mut self, a: &Self::TypeVec, shift: &Self::TypeVec) -> Self::TypeVec;
+
+    /// Shifts a vector to the right by a specified number of positions.
+    ///
+    /// # Parameters
+    ///
+    /// - `a`: A reference to the vector to be shifted.
+    /// - `shift`: A reference to the vector containing the number of positions to shift.
+    ///
+    /// # Returns
+    ///
+    /// A vector of elements resulting from the right shift operation.
+    fn shr(&mut self, a: &Self::TypeVec, shift: &Self::TypeVec) -> Self::TypeVec;
 }

--- a/compute/src/uint.rs
+++ b/compute/src/uint.rs
@@ -22,8 +22,8 @@ pub type GarbledUint1024 = GarbledUint<1024>;
 // Define a new type Uint<N>
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct GarbledUint<const N: usize> {
-    pub bits: Vec<bool>,              // Store the bits of the unsigned integer
-    _phantom: PhantomData<[bool; N]>, // PhantomData to ensure the N bit size
+    pub bits: Vec<bool>,
+    _phantom: PhantomData<[bool; N]>,
 }
 
 impl<const N: usize> GarbledUint<N> {
@@ -286,7 +286,22 @@ impl<const N: usize> From<GarbledUint<N>> for u128 {
     }
 }
 
-// Implement ruint::Uint support for GarbledUint<N>
+impl<const N: usize> From<usize> for GarbledUint<N> {
+    fn from(value: usize) -> Self {
+        assert!(
+            N <= (usize::BITS as usize),
+            "GarbledUint<N> can only support up to {} bits for usize",
+            usize::BITS
+        );
+
+        let mut bits = Vec::with_capacity(N);
+        for i in 0..N {
+            bits.push((value >> i) & 1 == 1);
+        }
+
+        GarbledUint::new(bits)
+    }
+}
 
 impl<const BITS: usize, const LIMBS: usize> TryFrom<GarbledUint<BITS>> for Uint<BITS, LIMBS> {
     type Error = ruint::ToUintError<Uint<BITS, LIMBS>>;

--- a/compute/tests/bitwise.rs
+++ b/compute/tests/bitwise.rs
@@ -578,7 +578,7 @@ fn test_int_left_shift_and_assign() {
 }
 
 #[test]
-fn test_right_shift_uint() {
+fn test_uint_right_shift() {
     let a = GarbledUint::<4>::new(vec![false, false, false, true]); // Binary 1000
 
     let result: u8 = (a >> 1).into(); // Perform right shift by 1


### PR DESCRIPTION
## **Problem**  
We needed to add dynamic shift operators (both left and right) for our garbled integers (both `GarbledUint` and `GarbledInt`) as part of our circuit SDK, so we can implement this as a circuit itself on revm.

## **Implementation**  
1. **Bit–Order Reversal:** 
   - Modified the shift operators so that the input is reversed (converting LSB–first to MSB–first), the circuit is executed, and then the result is reversed back to our native order.

2. **Operator Trait Integration:**  
   - Implemented the standard Rust operator traits (`Shl`, `Shr`, `ShlAssign`, and `ShrAssign`) for both `GarbledUint` and `GarbledInt`.
   - For `GarbledInt`, the operators convert the value to a `GarbledUint`, perform the shift, then convert back.
   - Both dynamic (with a garbled shift amount) and literal shift amounts (using `usize`) are supported.

3. **Testing:**  
   - Updated and ran comprehensive tests in our `tests/bitwise.rs` file.
   - All tests (including left/right shifts for both unsigned and signed types) now pass.

## **Outcome:** 
This pull request fixes the shift operator implementations by reconciling the bit–ordering differences between our internal representation and the circuit–builder expectations, and fully integrates shift operators for both garbled unsigned and signed integers.